### PR TITLE
Add network, home, removable-media interfaces to mysql commands

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,12 +36,16 @@ apps:
     plugs: [network, network-bind]
   mysql:
     command: usr/bin/mysql
+    plugs: [network, home, removable-media]
   mysqladmin:
     command: usr/bin/mysqladmin
+    plugs: [network, home, removable-media]
   mysqldump:
     command: usr/bin/mysqldump
+    plugs: [network, home, removable-media]
   mysqlimport:
     command: usr/bin/mysqlimport
+    plugs: [network, home, removable-media]
   rootpass:
     command: bin/rootpass.sh
 


### PR DESCRIPTION
The network interface allows for connecting to remote MySQL instances, while the home and removable-media interfaces allow for interacting with the local file system.